### PR TITLE
Add render caching + goodies

### DIFF
--- a/examples/background.rb
+++ b/examples/background.rb
@@ -85,7 +85,7 @@ class Cloud
   def draw(canvas)
     canvas.draw_sprite(
       @sprite,
-      x: @x.round,
+      x: @x,
       y: @y,
       fg: @color
     )

--- a/examples/grains_of_sand.rb
+++ b/examples/grains_of_sand.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "rich_engine"
+
+class GrainsOfSandExample < RichEngine::Game
+  using RichEngine::StringColors
+
+  def on_create
+    @canvas.bg = RichEngine::UI::Textures.solid.fg(:yellow)
+    @world = World.new(
+      grains_of_sand: [
+        GrainOfSand.new(x: @config[:screen_width] / 2, y: -1),
+        GrainOfSand.new(x: @config[:screen_width] / 2, y: -@config[:screen_height] / 2)
+      ],
+      game_config: @config
+    )
+  end
+
+  def on_update(elapsed_time, key)
+    quit! if key == :q
+
+    @world.update(elapsed_time, key)
+
+    @canvas.clear
+
+    @world.draw(@canvas)
+  end
+end
+
+class World
+  def initialize(grains_of_sand:, game_config:)
+    @grains_of_sand = grains_of_sand
+    @game_config = game_config
+    @tiles = RichEngine::Matrix.new(width: width, height: height, fill_with: :empty)
+    @place_drop_timer = RichEngine::Timer.every(seconds: 0.01)
+  end
+
+  def update(elapsed_time, _key)
+    @place_drop_timer.update(elapsed_time)
+
+    @place_drop_timer.when_ready do
+      drops_movement = @grains_of_sand.map { |grain_of_sand|
+        next :not_moved if locked?(grain_of_sand)
+
+        if fits?(*grain_of_sand.try_move(:down).position)
+          grain_of_sand.move_down
+          :moved
+        elsif fits?(*grain_of_sand.try_move(:down).try_move(:left).position)
+          grain_of_sand.move_down.move_left
+          :moved
+        elsif fits?(*grain_of_sand.try_move(:down).try_move(:right).position)
+          grain_of_sand.move_down.move_right
+          :moved
+        else
+          lock_drop(grain_of_sand)
+          :not_moved
+        end
+      }
+
+      first_drop_didnt_move = drops_movement.first == :not_moved
+      no_drops_moved = drops_movement.all? { _1 == :not_moved }
+
+      if no_drops_moved
+        raise RichEngine::Game::Exit
+      elsif first_drop_didnt_move && has_available_space?
+        @grains_of_sand << GrainOfSand.new(x: @game_config[:screen_width] / 2, y: 0)
+      end
+    end
+  end
+
+  def draw(canvas)
+    @grains_of_sand.each { _1.draw(canvas) }
+  end
+
+  private
+
+  def locked?(grain_of_sand)
+    @tiles[grain_of_sand.x, grain_of_sand.y] == :filled
+  end
+
+  def fits?(x, y)
+    x >= 0 && x < width && y < height && @tiles[x, y] != :filled
+  end
+
+  def lock_drop(grain_of_sand)
+    @tiles[grain_of_sand.x, grain_of_sand.y] = :filled
+  end
+
+  def has_available_space?
+    @tiles.any? { |tile| tile == :empty }
+  end
+
+  def width
+    @game_config[:screen_width]
+  end
+
+  def height
+    @game_config[:screen_height]
+  end
+end
+
+class GrainOfSand
+  using RichEngine::StringColors
+
+  attr_reader :x, :y
+
+  def initialize(x:, y:)
+    @x = x
+    @y = y
+  end
+
+  def try_move(move)
+    copy = dup
+
+    if move == :down
+      copy.move_down
+    elsif move == :left
+      copy.move_left
+    elsif move == :right
+      copy.move_right
+    else
+      raise "Unknown move: #{move}"
+    end
+  end
+
+  def position
+    [@x, @y]
+  end
+
+  def move_down
+    @y += 1
+
+    self
+  end
+
+  def move_left
+    @x -= 1
+
+    self
+  end
+
+  def move_right
+    @x += 1
+
+    self
+  end
+
+  def draw(canvas)
+    canvas.write_string("o", x: @x, y: @y, fg: :black, bg: :yellow)
+  end
+end
+
+GrainsOfSandExample.play(width: 60, height: 20)

--- a/examples/noise.rb
+++ b/examples/noise.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rich_engine"
+
+class NoiseExample < RichEngine::Game
+  def on_create
+    @end_timer = RichEngine::Timer.new
+    @change_timer = RichEngine::Timer.every(seconds: 0.1)
+  end
+
+  def on_update(elapsed_time, key)
+    quit! if key == :q
+
+    @end_timer.update(elapsed_time)
+    @change_timer.update(elapsed_time)
+
+    @change_timer.when_ready do
+      @canvas.clear
+      @canvas.each_coord do |x, y|
+        @canvas[x, y] = RichEngine::Chance.of_one_in(2) ? "█" : " "
+      end
+      @canvas.write_string(elapsed_time, x: 1, y: 1)
+    end
+
+    quit! if @end_timer.get > 10
+  end
+end
+
+NoiseExample.play(width: 80, height: 40)

--- a/lib/rich_engine.rb
+++ b/lib/rich_engine.rb
@@ -9,6 +9,7 @@ require_relative "rich_engine/matrix"
 require_relative "rich_engine/string_colors"
 require_relative "rich_engine/terminal"
 require_relative "rich_engine/timer"
+require_relative "rich_engine/timer/every"
 require_relative "rich_engine/ui/textures"
 require_relative "rich_engine/version"
 

--- a/lib/rich_engine/canvas.rb
+++ b/lib/rich_engine/canvas.rb
@@ -90,6 +90,9 @@ module RichEngine
     end
 
     def [](x, y)
+      x = x.round
+      y = y.round
+
       @canvas[at(x, y)]
     end
 

--- a/lib/rich_engine/canvas.rb
+++ b/lib/rich_engine/canvas.rb
@@ -19,6 +19,14 @@ module RichEngine
       [@width, @height]
     end
 
+    def each_coord(&block)
+      (0...@width).each do |x|
+        (0...@height).each do |y|
+          block.call(x, y)
+        end
+      end
+    end
+
     def draw_sprite(sprite, x: 0, y: 0, fg: :white)
       sprite.split("\n").each.with_index do |line, i|
         line.each_char.with_index do |char, j|
@@ -101,7 +109,7 @@ module RichEngine
     end
 
     def create_blank_canvas
-      @blank_canvas = (0...(@width * @height)).map { @bg }
+      (0...(@width * @height)).map { @bg }
     end
   end
 end

--- a/lib/rich_engine/canvas.rb
+++ b/lib/rich_engine/canvas.rb
@@ -55,6 +55,11 @@ module RichEngine
     end
 
     def draw_rect(x:, y:, width:, height:, char: "█", color: :white)
+      x = x.round
+      y = y.round
+      width = width.round
+      height = height.round
+
       (x..(x + width - 1)).each do |x_pos|
         (y..(y + height - 1)).each do |y_pos|
           self[x_pos, y_pos] = char.fg(color)
@@ -63,6 +68,9 @@ module RichEngine
     end
 
     def draw_circle(x:, y:, radius:, char: "█", color: :white)
+      x = x.round
+      y = y.round
+
       (x - radius..x + radius).each do |x_pos|
         (y - radius..y + radius).each do |y_pos|
           next if (x_pos - x)**2 + (y_pos - y)**2 > radius**2
@@ -86,6 +94,8 @@ module RichEngine
     end
 
     def []=(x, y, value)
+      x = x.round
+      y = y.round
       return if out_of_bounds?(x, y)
 
       @canvas[at(x, y)] = value

--- a/lib/rich_engine/chance.rb
+++ b/lib/rich_engine/chance.rb
@@ -11,5 +11,9 @@ module RichEngine
 
       rand_gen.call < percent
     end
+
+    def self.of_one_in(value, rand_gen: method(:rand))
+      of(1 / value.to_f, rand_gen: rand_gen)
+    end
   end
 end

--- a/lib/rich_engine/game.rb
+++ b/lib/rich_engine/game.rb
@@ -31,7 +31,7 @@ module RichEngine
       @canvas = RichEngine::Canvas.new(width, height)
     end
 
-    def self.play(width = 50, height = 10)
+    def self.play(width: 50, height: 10)
       new(width, height).play
     end
 

--- a/lib/rich_engine/game.rb
+++ b/lib/rich_engine/game.rb
@@ -81,8 +81,8 @@ module RichEngine
       @io.read_async
     end
 
-    def render
-      @io.write(@canvas.canvas)
+    def render(use_caching: true)
+      @io.write(@canvas.canvas, use_caching: use_caching)
     end
 
     def check_exit

--- a/lib/rich_engine/io.rb
+++ b/lib/rich_engine/io.rb
@@ -5,6 +5,8 @@ require "io/console"
 
 module RichEngine
   class IO
+    Signal.trap("INT") { raise Game::Exit }
+
     def initialize(width, height)
       @width = width
       @height = height

--- a/lib/rich_engine/io.rb
+++ b/lib/rich_engine/io.rb
@@ -51,7 +51,7 @@ module RichEngine
     end
 
     def with_caching(canvas)
-      return :cache_hit if canvas == @canvas_cache && ENV["CACHING"]
+      return :cache_hit if canvas == @canvas_cache
 
       yield
       @canvas_cache = canvas

--- a/lib/rich_engine/io.rb
+++ b/lib/rich_engine/io.rb
@@ -15,7 +15,7 @@ module RichEngine
 
     def write(canvas)
       with_caching(canvas) do
-        Terminal::Cursor.go(:home)
+        Terminal::Cursor.goto(0, 0)
         output = build_output(canvas)
         $stdout.write output
       end

--- a/lib/rich_engine/io.rb
+++ b/lib/rich_engine/io.rb
@@ -10,7 +10,7 @@ module RichEngine
     def initialize(width, height)
       @screen_width = width
       @screen_height = height
-      @canvas_cache = nil
+      delete_cache
     end
 
     def write(canvas, use_caching:)

--- a/lib/rich_engine/io.rb
+++ b/lib/rich_engine/io.rb
@@ -13,7 +13,9 @@ module RichEngine
       @canvas_cache = nil
     end
 
-    def write(canvas)
+    def write(canvas, use_caching:)
+      delete_cache unless use_caching
+
       with_caching(canvas) do
         Terminal::Cursor.goto(0, 0)
         output = build_output(canvas)
@@ -43,6 +45,10 @@ module RichEngine
     end
 
     private
+
+    def delete_cache
+      @canvas_cache = nil
+    end
 
     def with_caching(canvas)
       return :cache_hit if canvas == @canvas_cache && ENV["CACHING"]

--- a/lib/rich_engine/matrix.rb
+++ b/lib/rich_engine/matrix.rb
@@ -2,6 +2,8 @@
 
 module RichEngine
   class Matrix
+    # TODO: implement Enumerable
+
     attr_accessor :vec
 
     def initialize(width: 1, height: 1, fill_with: nil)
@@ -14,6 +16,10 @@ module RichEngine
 
     def []=(x, y, value)
       @vec[x][y] = value
+    end
+
+    def any?(&block)
+      @vec.any? { |row| row.any?(&block) }
     end
 
     def each

--- a/lib/rich_engine/terminal.rb
+++ b/lib/rich_engine/terminal.rb
@@ -19,11 +19,11 @@ module RichEngine
     end
 
     def disable_echo
-      system("stty -echo")
+      $stdin.echo = false
     end
 
     def enable_echo
-      system("stty echo")
+      $stdin.echo = true
     end
   end
 end

--- a/lib/rich_engine/terminal/cursor.rb
+++ b/lib/rich_engine/terminal/cursor.rb
@@ -3,7 +3,7 @@
 module RichEngine
   module Terminal
     module Cursor
-      module_function
+      extend self
 
       def hide
         system("tput civis")
@@ -14,7 +14,7 @@ module RichEngine
       end
 
       def go(position)
-        print at(position)
+        $stdout.print at(position)
       end
 
       def at(position)

--- a/lib/rich_engine/terminal/cursor.rb
+++ b/lib/rich_engine/terminal/cursor.rb
@@ -13,17 +13,8 @@ module RichEngine
         system("tput cnorm")
       end
 
-      def go(position)
-        $stdout.print at(position)
-      end
-
-      def at(position)
-        case position
-        when :home then "\e[H"
-        when :up then "\e[A"
-        when :down then "\e[B"
-        else raise "Invalid cursor position: '#{position}'"
-        end
+      def goto(x, y)
+        $stdout.goto(x, y)
       end
     end
   end

--- a/lib/rich_engine/timer.rb
+++ b/lib/rich_engine/timer.rb
@@ -2,6 +2,10 @@
 
 module RichEngine
   class Timer
+    def self.every(seconds: 1, &block)
+      Every.new(seconds)
+    end
+
     def initialize
       @timer = 0
     end

--- a/lib/rich_engine/timer/every.rb
+++ b/lib/rich_engine/timer/every.rb
@@ -24,6 +24,11 @@ module RichEngine
         end
       end
 
+      def interval=(interval)
+        @interval = interval
+        reset!
+      end
+
       private
 
       def reset!

--- a/lib/rich_engine/timer/every.rb
+++ b/lib/rich_engine/timer/every.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module RichEngine
+  class Timer
+    class Every
+      def initialize(interval)
+        @interval = interval
+        @ready = false
+        @timer = Timer.new
+      end
+
+      def update(elapsed_time)
+        @timer.update(elapsed_time)
+
+        if @timer.get >= @interval
+          @ready = true
+        end
+      end
+
+      def when_ready(&block)
+        if @ready
+          block.call
+          reset!
+        end
+      end
+
+      private
+
+      def reset!
+        @timer.reset!
+        @ready = false
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add render caching
  - No need to update the screen if the contents are the same.
  - In some cases, the cache hit percentage was up to 90%.
- Allow float values to be passed to Canvas (they will be rounded on print)
- Add `Timer.every`
- Add several new examples
- Some refactoring across the codebase